### PR TITLE
Add packet preview to logs to enhance debugging

### DIFF
--- a/cory-core/src/main/java/moe/rafal/cory/CoryBuilder.java
+++ b/cory-core/src/main/java/moe/rafal/cory/CoryBuilder.java
@@ -17,7 +17,7 @@
 
 package moe.rafal.cory;
 
-import static moe.rafal.cory.logger.LoggerFacade.getCoryLogger;
+import static moe.rafal.cory.logger.LoggerFacade.getNoopLogger;
 import static moe.rafal.cory.message.packet.PacketListenerObserver.getPacketListenerObserver;
 import static moe.rafal.cory.message.packet.PacketPublisher.getPacketPublisher;
 import static moe.rafal.cory.message.packet.PacketRequester.getPacketRequester;
@@ -31,7 +31,7 @@ import moe.rafal.cory.serdes.PacketSerdesContext;
 
 public final class CoryBuilder {
 
-  private LoggerFacade loggerFacade = getCoryLogger(false);
+  private LoggerFacade loggerFacade = getNoopLogger();
   private MessageBroker messageBroker;
   private PacketSerdesContext serdesContext;
 
@@ -67,12 +67,12 @@ public final class CoryBuilder {
           "Cory could not be built, because of missing packet serdes context.");
     }
 
-    PacketGateway packetGateway = PacketGateway.INSTANCE;
-    PacketPublisher packetPublisher =
+    final PacketGateway packetGateway = PacketGateway.INSTANCE;
+    final PacketPublisher packetPublisher =
         getPacketPublisher(loggerFacade, messageBroker, packetGateway, serdesContext);
-    PacketRequester packetRequester =
+    final PacketRequester packetRequester =
         getPacketRequester(loggerFacade, messageBroker, packetGateway, serdesContext);
-    PacketListenerObserver packetListenerObserver =
+    final PacketListenerObserver packetListenerObserver =
         getPacketListenerObserver(
             loggerFacade, messageBroker, packetGateway, packetPublisher, serdesContext);
     return new CoryImpl(

--- a/cory-core/src/main/java/moe/rafal/cory/logger/payload/PayloadConversionException.java
+++ b/cory-core/src/main/java/moe/rafal/cory/logger/payload/PayloadConversionException.java
@@ -15,20 +15,11 @@
  *
  */
 
-package moe.rafal.cory.logger;
+package moe.rafal.cory.logger.payload;
 
-import java.util.logging.Level;
-import moe.rafal.cory.serdes.PacketSerdesContext;
+public class PayloadConversionException extends IllegalStateException {
 
-public interface LoggerFacade {
-
-  static LoggerFacade getCoryLogger(final PacketSerdesContext serdesContext, final boolean debug) {
-    return new CoryLogger(serdesContext, debug);
+  public PayloadConversionException(final String message, final Throwable cause) {
+    super(message, cause);
   }
-
-  static LoggerFacade getNoopLogger() {
-    return new NoopLogger();
-  }
-
-  void log(final Level level, final String message, final Object... parameters);
 }

--- a/cory-core/src/main/java/moe/rafal/cory/logger/payload/PayloadUtils.java
+++ b/cory-core/src/main/java/moe/rafal/cory/logger/payload/PayloadUtils.java
@@ -1,0 +1,57 @@
+/*
+ *    Copyright 2023-2024 cory
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package moe.rafal.cory.logger.payload;
+
+import java.util.HashSet;
+import java.util.Set;
+import moe.rafal.cory.Packet;
+import moe.rafal.cory.serdes.PacketPacker;
+import moe.rafal.cory.serdes.PacketSerdesContext;
+import moe.rafal.cory.serdes.PacketUnpacker;
+
+public final class PayloadUtils {
+
+  private PayloadUtils() {}
+
+  public static String getPacketPreview(
+      final PacketSerdesContext serdesContext, final byte[] payload) {
+    final Set<Object> elements = new HashSet<>();
+    try (final PacketUnpacker unpacker = serdesContext.newPacketUnpacker(payload)) {
+      while (unpacker.hasNext() && !unpacker.hasNextNilValue()) {
+        elements.add(unpacker.unpackObject());
+      }
+    } catch (final Exception exception) {
+      throw new PayloadConversionException(
+          "Could not convert packet payload to preview, because of unexpected exception.",
+          exception);
+    }
+    return elements.toString();
+  }
+
+  public static byte[] getPacketPayload(
+      final PacketSerdesContext serdesContext, final Packet packet) {
+    try (final PacketPacker packer = serdesContext.newPacketPacker()) {
+      packet.write(packer);
+      return packer.toBinaryArray();
+    } catch (final Exception exception) {
+      throw new PayloadConversionException(
+          "Could not process convert payload to preview, because of unexpected exception.",
+          exception);
+    }
+  }
+}

--- a/cory-core/src/main/java/moe/rafal/cory/message/packet/PacketListenerObserverImpl.java
+++ b/cory-core/src/main/java/moe/rafal/cory/message/packet/PacketListenerObserverImpl.java
@@ -30,11 +30,11 @@ import moe.rafal.cory.serdes.PacketUnpacker;
 class PacketListenerObserverImpl implements PacketListenerObserver {
 
   private static final String RECEIVED_PACKET =
-      "Received packet of type %s (%s) from %s channel with %s reply channel.";
+      "Received packet of type %s (%s) from %s channel with %s reply channel. Preview: %s";
   private static final String RECEIVED_AND_FORWARDED_PACKET =
-      "Received packet of type %s (%s) from %s channel with %s reply channel and forwarded to %s listener.";
+      "Received packet of type %s (%s) from %s channel with %s reply channel and forwarded to %s listener. Preview: %s";
   private static final String RECEIVED_AND_RESPONDED_PACKET =
-      "Received packet of type %s (%s) from %s channel with %s reply channel and responded with %s packet.";
+      "Received packet of type %s (%s) from %s channel with %s reply channel and responded with %s packet. Preview: %s";
   private final LoggerFacade loggerFacade;
   private final MessageBroker messageBroker;
   private final PacketGateway packetGateway;
@@ -131,7 +131,8 @@ class PacketListenerObserverImpl implements PacketListenerObserver {
         packet.getClass().getName(),
         packet.getUniqueId(),
         channelName,
-        replyChannelName);
+        replyChannelName,
+        packet);
   }
 
   private void logReceivedAndForwardedPacket(
@@ -146,7 +147,8 @@ class PacketListenerObserverImpl implements PacketListenerObserver {
         packet.getUniqueId(),
         channelName,
         replyChannelName,
-        packetListener.getClass().getName());
+        packetListener.getClass().getName(),
+        packet);
   }
 
   private void logReceivedAndRespondedPacket(
@@ -158,6 +160,7 @@ class PacketListenerObserverImpl implements PacketListenerObserver {
         packet.getUniqueId(),
         channelName,
         replyChannelName,
-        responsePacket.getClass().getName());
+        responsePacket.getClass().getName(),
+        packet);
   }
 }

--- a/cory-core/src/main/java/moe/rafal/cory/message/packet/PacketPublisherImpl.java
+++ b/cory-core/src/main/java/moe/rafal/cory/message/packet/PacketPublisherImpl.java
@@ -30,9 +30,9 @@ import moe.rafal.cory.serdes.PacketSerdesContext;
 class PacketPublisherImpl implements PacketPublisher {
 
   private static final String PACKET_PUBLISHING_STARTING =
-      "Publishing packet of type %s (%s) over the channel %s.";
+      "Publishing packet of type %s (%s) over the channel %s. Preview: %s";
   private static final String PACKET_PUBLISHING_COMPLETED =
-      "Packet of type %s (%s) has been published over the %s channel with payload of %d bytes.";
+      "Packet of type %s (%s) has been published over the %s channel with payload of %d bytes. Preview: %s";
   private final LoggerFacade loggerFacade;
   private final MessageBroker messageBroker;
   private final PacketGateway packetGateway;
@@ -70,7 +70,8 @@ class PacketPublisherImpl implements PacketPublisher {
         PACKET_PUBLISHING_STARTING,
         packet.getClass().getSimpleName(),
         packet.getUniqueId(),
-        channelName);
+        channelName,
+        packet);
   }
 
   private void logPacketPublicationCompletion(Packet packet, String channelName, byte[] payload) {
@@ -80,6 +81,7 @@ class PacketPublisherImpl implements PacketPublisher {
         packet.getClass().getSimpleName(),
         packet.getUniqueId(),
         channelName,
-        payload.length);
+        payload.length,
+        packet);
   }
 }

--- a/cory-core/src/main/java/moe/rafal/cory/message/packet/PacketRequesterImpl.java
+++ b/cory-core/src/main/java/moe/rafal/cory/message/packet/PacketRequesterImpl.java
@@ -34,11 +34,11 @@ import moe.rafal.cory.serdes.PacketUnpacker;
 class PacketRequesterImpl implements PacketRequester {
 
   private static final String PACKET_REQUESTING_STARTING =
-      "Requesting packet of type %s (%s) over the channel %s.";
+      "Requesting packet of type %s (%s) over the channel %s. Preview: %s";
   private static final String PACKET_REQUESTING_COMPLETED =
-      "Request of packet of type %s (%s) has been completed over the %s channel with payload of %d bytes.";
+      "Request of packet of type %s (%s) has been completed over the %s channel with payload of %d bytes. Preview: %s";
   private static final String PACKET_REQUESTING_FULFILLED =
-      "Request of packet of type %s (%s) has been fulfilled over the temporary channel with payload of %d bytes.";
+      "Request of packet of type %s (%s) has been fulfilled over the temporary channel with payload of %d bytes. Preview: %s";
   private final LoggerFacade loggerFacade;
   private final MessageBroker messageBroker;
   private final PacketGateway packetGateway;
@@ -103,7 +103,8 @@ class PacketRequesterImpl implements PacketRequester {
         PACKET_REQUESTING_STARTING,
         packet.getClass().getSimpleName(),
         packet.getUniqueId(),
-        channelName);
+        channelName,
+        packet);
   }
 
   private void logPacketRequestingCompletion(Packet packet, String channelName, byte[] payload) {
@@ -113,7 +114,8 @@ class PacketRequesterImpl implements PacketRequester {
         packet.getClass().getSimpleName(),
         packet.getUniqueId(),
         channelName,
-        payload.length);
+        payload.length,
+        packet);
   }
 
   private void logPacketRequestingFulfilled(Packet packet, byte[] payload) {
@@ -122,6 +124,7 @@ class PacketRequesterImpl implements PacketRequester {
         PACKET_REQUESTING_FULFILLED,
         packet.getClass().getSimpleName(),
         packet.getUniqueId(),
-        payload.length);
+        payload.length,
+        packet);
   }
 }

--- a/cory-core/src/main/java/moe/rafal/cory/serdes/PacketUnpacker.java
+++ b/cory-core/src/main/java/moe/rafal/cory/serdes/PacketUnpacker.java
@@ -64,6 +64,8 @@ public interface PacketUnpacker extends Closeable {
 
   <T extends Enum<T>> T unpackEnum() throws IOException;
 
+  Object unpackObject() throws IOException;
+
   <T> T unpackAuto() throws IOException;
 
   boolean hasNext() throws IOException;

--- a/cory-examples/ping-pong-client/src/main/java/moe/rafal/example/PongClient.java
+++ b/cory-examples/ping-pong-client/src/main/java/moe/rafal/example/PongClient.java
@@ -2,25 +2,26 @@ package moe.rafal.example;
 
 import static moe.rafal.cory.logger.LoggerFacade.getCoryLogger;
 import static moe.rafal.cory.message.RedisMessageBrokerFactory.getRedisMessageBroker;
+import static moe.rafal.cory.serdes.MessagePackPacketSerdesContext.getMessagePackPacketSerdesContext;
 
 import io.lettuce.core.RedisURI;
 import moe.rafal.cory.Cory;
 import moe.rafal.cory.CoryBuilder;
-import moe.rafal.cory.serdes.MessagePackPacketSerdesContext;
+import moe.rafal.cory.serdes.PacketSerdesContext;
 import moe.rafal.example.proto.c2s.PingPacket;
 import moe.rafal.example.proto.s2c.PongPacket;
 
 public class PongClient {
 
   public static void main(String[] args) {
+    PacketSerdesContext serdesContext = getMessagePackPacketSerdesContext();
+
     Cory cory =
         CoryBuilder.newBuilder()
-            .withLoggerFacade(getCoryLogger(true))
-            .withSerdesContext(MessagePackPacketSerdesContext.INSTANCE)
+            .withLoggerFacade(getCoryLogger(serdesContext, true))
+            .withSerdesContext(serdesContext)
             .withMessageBroker(
-                getRedisMessageBroker(
-                    MessagePackPacketSerdesContext.INSTANCE,
-                    RedisURI.create("redis://localhost:6379")))
+                getRedisMessageBroker(serdesContext, RedisURI.create("redis://localhost:6379")))
             .build();
     cory.<PingPacket, PongPacket>request("ping-pong", getPingPacket())
         .thenAccept(

--- a/cory-examples/ping-pong-proto/src/main/java/moe/rafal/example/proto/c2s/PingPacket.java
+++ b/cory-examples/ping-pong-proto/src/main/java/moe/rafal/example/proto/c2s/PingPacket.java
@@ -1,12 +1,25 @@
 package moe.rafal.example.proto.c2s;
 
-import moe.rafal.cory.pojo.PojoPacket;
+import java.io.IOException;
+import moe.rafal.cory.Packet;
+import moe.rafal.cory.serdes.PacketPacker;
+import moe.rafal.cory.serdes.PacketUnpacker;
 
-public class PingPacket extends PojoPacket {
+public class PingPacket extends Packet {
 
   private String message;
 
   public PingPacket() {}
+
+  @Override
+  public void write(final PacketPacker packer) throws IOException {
+    packer.packString(message);
+  }
+
+  @Override
+  public void read(final PacketUnpacker unpacker) throws IOException {
+    message = unpacker.unpackString();
+  }
 
   public String getMessage() {
     return message;

--- a/cory-examples/ping-pong-server/src/main/java/moe/rafal/example/PongServer.java
+++ b/cory-examples/ping-pong-server/src/main/java/moe/rafal/example/PongServer.java
@@ -2,23 +2,24 @@ package moe.rafal.example;
 
 import static moe.rafal.cory.logger.LoggerFacade.getCoryLogger;
 import static moe.rafal.cory.message.RedisMessageBrokerFactory.getRedisMessageBroker;
+import static moe.rafal.cory.serdes.MessagePackPacketSerdesContext.getMessagePackPacketSerdesContext;
 
 import io.lettuce.core.RedisURI;
 import moe.rafal.cory.Cory;
 import moe.rafal.cory.CoryBuilder;
-import moe.rafal.cory.serdes.MessagePackPacketSerdesContext;
+import moe.rafal.cory.serdes.PacketSerdesContext;
 
 public class PongServer {
 
   public static void main(String[] args) {
+    PacketSerdesContext serdesContext = getMessagePackPacketSerdesContext();
+
     Cory cory =
         CoryBuilder.newBuilder()
-            .withLoggerFacade(getCoryLogger(true))
-            .withSerdesContext(MessagePackPacketSerdesContext.INSTANCE)
+            .withLoggerFacade(getCoryLogger(serdesContext, true))
+            .withSerdesContext(serdesContext)
             .withMessageBroker(
-                getRedisMessageBroker(
-                    MessagePackPacketSerdesContext.INSTANCE,
-                    RedisURI.create("redis://localhost:6379")))
+                getRedisMessageBroker(serdesContext, RedisURI.create("redis://localhost:6379")))
             .build();
     cory.mutualObserve("ping-pong", new PongListener());
 

--- a/cory-message-broker-nats/src/test/java/moe/rafal/cory/message/CoryImplTests.java
+++ b/cory-message-broker-nats/src/test/java/moe/rafal/cory/message/CoryImplTests.java
@@ -24,6 +24,7 @@ import static moe.rafal.cory.PacketTestsUtils.getLoginRequestPacket;
 import static moe.rafal.cory.integration.nats.EmbeddedNatsServerExtension.getNatsConnectionUri;
 import static moe.rafal.cory.logger.LoggerFacade.getNoopLogger;
 import static moe.rafal.cory.message.NatsMessageBrokerFactory.produceNatsMessageBroker;
+import static moe.rafal.cory.serdes.MessagePackPacketSerdesContext.getMessagePackPacketSerdesContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.awaitility.Awaitility.await;
@@ -38,7 +39,6 @@ import moe.rafal.cory.Packet;
 import moe.rafal.cory.integration.nats.EmbeddedNatsServerExtension;
 import moe.rafal.cory.integration.nats.InjectNatsServer;
 import moe.rafal.cory.message.packet.PacketListenerDelegate;
-import moe.rafal.cory.serdes.MessagePackPacketSerdesContext;
 import moe.rafal.cory.subject.LoginPacket;
 import moe.rafal.cory.subject.LoginRequestPacket;
 import np.com.madanpokharel.embed.nats.EmbeddedNatsServer;
@@ -61,7 +61,7 @@ class CoryImplTests {
             .withMessageBroker(
                 produceNatsMessageBroker(
                     Options.builder().server(getNatsConnectionUri(natsServer)).build()))
-            .withSerdesContext(MessagePackPacketSerdesContext.INSTANCE)
+            .withSerdesContext(getMessagePackPacketSerdesContext())
             .build();
   }
 

--- a/cory-message-broker-nats/src/test/java/moe/rafal/cory/message/packet/PackerPublisherImplTests.java
+++ b/cory-message-broker-nats/src/test/java/moe/rafal/cory/message/packet/PackerPublisherImplTests.java
@@ -26,6 +26,7 @@ import static moe.rafal.cory.integration.nats.EmbeddedNatsServerExtension.getNat
 import static moe.rafal.cory.logger.LoggerFacade.getNoopLogger;
 import static moe.rafal.cory.message.NatsMessageBrokerFactory.produceNatsMessageBroker;
 import static moe.rafal.cory.message.packet.PacketPublisher.getPacketPublisher;
+import static moe.rafal.cory.serdes.MessagePackPacketSerdesContext.getMessagePackPacketSerdesContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.awaitility.Awaitility.await;
@@ -43,7 +44,6 @@ import moe.rafal.cory.integration.nats.EmbeddedNatsServerExtension;
 import moe.rafal.cory.integration.nats.InjectNatsServer;
 import moe.rafal.cory.logger.LoggerFacade;
 import moe.rafal.cory.message.MessageBroker;
-import moe.rafal.cory.serdes.MessagePackPacketSerdesContext;
 import moe.rafal.cory.serdes.PacketSerdesContext;
 import moe.rafal.cory.serdes.PacketUnpacker;
 import moe.rafal.cory.subject.LoginPacket;
@@ -71,7 +71,7 @@ class PackerPublisherImplTests {
             loggerFacade,
             messageBroker,
             PacketGateway.INSTANCE,
-            MessagePackPacketSerdesContext.INSTANCE);
+            getMessagePackPacketSerdesContext());
   }
 
   @Test
@@ -88,7 +88,7 @@ class PackerPublisherImplTests {
             () -> {
               assertThat(receivedPayload).isNotNull();
               try (PacketUnpacker unpacker =
-                  MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(
+                  getMessagePackPacketSerdesContext().newPacketUnpacker(
                       receivedPayload.get())) {
                 assertThatUnpackerContains(
                     unpacker, PacketUnpacker::unpackString, packet.getClass().getName());

--- a/cory-message-broker-nats/src/test/java/moe/rafal/cory/message/packet/PacketListenerObserverImplTests.java
+++ b/cory-message-broker-nats/src/test/java/moe/rafal/cory/message/packet/PacketListenerObserverImplTests.java
@@ -26,6 +26,7 @@ import static moe.rafal.cory.logger.LoggerFacade.getNoopLogger;
 import static moe.rafal.cory.message.NatsMessageBrokerFactory.produceNatsMessageBroker;
 import static moe.rafal.cory.message.packet.PacketListenerObserver.getPacketListenerObserver;
 import static moe.rafal.cory.message.packet.PacketPublisher.getPacketPublisher;
+import static moe.rafal.cory.serdes.MessagePackPacketSerdesContext.getMessagePackPacketSerdesContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.awaitility.Awaitility.await;
@@ -39,7 +40,6 @@ import moe.rafal.cory.integration.nats.EmbeddedNatsServerExtension;
 import moe.rafal.cory.integration.nats.InjectNatsServer;
 import moe.rafal.cory.logger.LoggerFacade;
 import moe.rafal.cory.message.MessageBroker;
-import moe.rafal.cory.serdes.MessagePackPacketSerdesContext;
 import moe.rafal.cory.serdes.PacketPacker;
 import moe.rafal.cory.subject.LoginPacket;
 import np.com.madanpokharel.embed.nats.EmbeddedNatsServer;
@@ -64,14 +64,14 @@ class PacketListenerObserverImplTests {
             Options.builder().server(getNatsConnectionUri(natsServer)).build());
     packetPublisher =
         getPacketPublisher(
-            loggerFacade, messageBroker, packetGateway, MessagePackPacketSerdesContext.INSTANCE);
+            loggerFacade, messageBroker, packetGateway, getMessagePackPacketSerdesContext());
     packetListenerObserver =
         getPacketListenerObserver(
             loggerFacade,
             messageBroker,
             packetGateway,
             packetPublisher,
-            MessagePackPacketSerdesContext.INSTANCE);
+            getMessagePackPacketSerdesContext());
   }
 
   @Test
@@ -118,7 +118,7 @@ class PacketListenerObserverImplTests {
 
   @Test
   void processIncomingPacketTest() throws IOException {
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       LoginPacket packet = getLoginPacket();
       packetGateway.writePacket(packet, packer);
       LoginPacket processedPacket =
@@ -129,7 +129,7 @@ class PacketListenerObserverImplTests {
 
   @Test
   void processIncomingPacketShouldThrowWhenMalformedTest() throws IOException {
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packer.packString("Hello");
       packer.packString("World");
       byte[] content = packer.toBinaryArray();

--- a/cory-message-broker-nats/src/test/java/moe/rafal/cory/message/packet/PacketRequesterImplTests.java
+++ b/cory-message-broker-nats/src/test/java/moe/rafal/cory/message/packet/PacketRequesterImplTests.java
@@ -23,6 +23,7 @@ import static moe.rafal.cory.integration.nats.EmbeddedNatsServerExtension.getNat
 import static moe.rafal.cory.logger.LoggerFacade.getNoopLogger;
 import static moe.rafal.cory.message.NatsMessageBrokerFactory.produceNatsMessageBroker;
 import static moe.rafal.cory.message.packet.PacketRequester.getPacketRequester;
+import static moe.rafal.cory.serdes.MessagePackPacketSerdesContext.getMessagePackPacketSerdesContext;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -37,7 +38,6 @@ import moe.rafal.cory.integration.nats.EmbeddedNatsServerExtension;
 import moe.rafal.cory.integration.nats.InjectNatsServer;
 import moe.rafal.cory.logger.LoggerFacade;
 import moe.rafal.cory.message.MessageBroker;
-import moe.rafal.cory.serdes.MessagePackPacketSerdesContext;
 import moe.rafal.cory.serdes.PacketPacker;
 import np.com.madanpokharel.embed.nats.EmbeddedNatsServer;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,7 +62,7 @@ class PacketRequesterImplTests {
             loggerFacade,
             messageBroker,
             PacketGateway.INSTANCE,
-            MessagePackPacketSerdesContext.INSTANCE);
+            getMessagePackPacketSerdesContext());
   }
 
   @Test
@@ -84,8 +84,8 @@ class PacketRequesterImplTests {
             loggerFacade,
             messageBroker,
             packetGatewayMock,
-            MessagePackPacketSerdesContext.INSTANCE);
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+            getMessagePackPacketSerdesContext());
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packer.packString("Hello");
       packer.packString("World");
       byte[] content = packer.toBinaryArray();

--- a/cory-message-broker-redis/src/test/java/moe/rafal/cory/message/RedisMessageBrokerFactoryTests.java
+++ b/cory-message-broker-redis/src/test/java/moe/rafal/cory/message/RedisMessageBrokerFactoryTests.java
@@ -18,11 +18,11 @@
 package moe.rafal.cory.message;
 
 import static moe.rafal.cory.message.RedisMessageBrokerFactory.getRedisMessageBroker;
+import static moe.rafal.cory.serdes.MessagePackPacketSerdesContext.getMessagePackPacketSerdesContext;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.lettuce.core.RedisConnectionException;
 import io.lettuce.core.RedisURI;
-import moe.rafal.cory.serdes.MessagePackPacketSerdesContext;
 import org.junit.jupiter.api.Test;
 
 class RedisMessageBrokerFactoryTests {
@@ -34,7 +34,7 @@ class RedisMessageBrokerFactoryTests {
     assertThatCode(
             () ->
                 getRedisMessageBroker(
-                    MessagePackPacketSerdesContext.INSTANCE,
+                    getMessagePackPacketSerdesContext(),
                     RedisURI.create(INVALID_CONNECTION_URI)))
         .isInstanceOf(RedisConnectionException.class)
         .hasMessageStartingWith("Unable to connect to ");

--- a/cory-message-broker-redis/src/test/java/moe/rafal/cory/message/RedisMessageBrokerTests.java
+++ b/cory-message-broker-redis/src/test/java/moe/rafal/cory/message/RedisMessageBrokerTests.java
@@ -27,6 +27,7 @@ import static moe.rafal.cory.PacketTestsUtils.BROADCAST_TEST_PAYLOAD;
 import static moe.rafal.cory.PacketTestsUtils.MAXIMUM_RESPONSE_PERIOD;
 import static moe.rafal.cory.integration.redis.EmbeddedRedisServerExtension.getRedisConnectionUri;
 import static moe.rafal.cory.message.RedisMessageBrokerFactory.getRedisMessageBroker;
+import static moe.rafal.cory.serdes.MessagePackPacketSerdesContext.getMessagePackPacketSerdesContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.awaitility.Awaitility.await;
@@ -37,14 +38,12 @@ import static org.mockito.Mockito.verify;
 
 import com.github.fppt.jedismock.RedisServer;
 import io.lettuce.core.RedisURI;
-import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import moe.rafal.cory.integration.redis.EmbeddedRedisServerExtension;
 import moe.rafal.cory.integration.redis.InjectRedisServer;
-import moe.rafal.cory.serdes.MessagePackPacketSerdesContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -61,12 +60,12 @@ class RedisMessageBrokerTests {
     messageBroker =
         (RedisMessageBroker)
             getRedisMessageBroker(
-                MessagePackPacketSerdesContext.INSTANCE,
+                getMessagePackPacketSerdesContext(),
                 RedisURI.create(getRedisConnectionUri(redisServer)));
     messageBrokerWhichIsFailing =
         (RedisMessageBroker)
             RedisMessageBrokerFactory.getRedisMessageBroker(
-                MessagePackPacketSerdesContext.INSTANCE,
+                getMessagePackPacketSerdesContext(),
                 RedisURI.create(getRedisConnectionUri(redisServer)),
                 ZERO);
   }

--- a/cory-message-broker-redis/src/test/java/moe/rafal/cory/message/RedisMessageBrokerTestsUtils.java
+++ b/cory-message-broker-redis/src/test/java/moe/rafal/cory/message/RedisMessageBrokerTestsUtils.java
@@ -19,10 +19,10 @@ package moe.rafal.cory.message;
 
 import static java.util.UUID.randomUUID;
 import static moe.rafal.cory.PacketTestsUtils.BROADCAST_TEST_PAYLOAD;
+import static moe.rafal.cory.serdes.MessagePackPacketSerdesContext.getMessagePackPacketSerdesContext;
 
 import java.io.IOException;
 import java.util.UUID;
-import moe.rafal.cory.serdes.MessagePackPacketSerdesContext;
 import moe.rafal.cory.serdes.PacketPacker;
 
 final class RedisMessageBrokerTestsUtils {
@@ -30,7 +30,7 @@ final class RedisMessageBrokerTestsUtils {
   private RedisMessageBrokerTestsUtils() {}
 
   static byte[] getPayloadWithRequestUniqueId(UUID requestUniqueId) throws IOException {
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packer.packUUID(requestUniqueId);
       packer.packBinaryHeader(BROADCAST_TEST_PAYLOAD.length);
       packer.packPayload(BROADCAST_TEST_PAYLOAD);

--- a/cory-message-broker-redis/src/test/java/moe/rafal/cory/message/RedisMessageListenerTests.java
+++ b/cory-message-broker-redis/src/test/java/moe/rafal/cory/message/RedisMessageListenerTests.java
@@ -21,6 +21,7 @@ import static java.lang.String.format;
 import static moe.rafal.cory.PacketTestsUtils.BROADCAST_CHANNEL_NAME;
 import static moe.rafal.cory.PacketTestsUtils.BROADCAST_TEST_PAYLOAD;
 import static moe.rafal.cory.message.RedisMessageBrokerTestsUtils.getPayloadWithRequestUniqueId;
+import static moe.rafal.cory.serdes.MessagePackPacketSerdesContext.getMessagePackPacketSerdesContext;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -29,7 +30,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
-import moe.rafal.cory.serdes.MessagePackPacketSerdesContext;
 import org.junit.jupiter.api.Test;
 
 class RedisMessageListenerTests {
@@ -60,7 +60,7 @@ class RedisMessageListenerTests {
         .receive(any(), any(), any());
     RedisMessageListener redisMessageListener =
         new RedisMessageListener(
-            MessagePackPacketSerdesContext.INSTANCE, BROADCAST_CHANNEL_NAME, messageListenerMock);
+            getMessagePackPacketSerdesContext(), BROADCAST_CHANNEL_NAME, messageListenerMock);
     assertThatCode(
             () ->
                 redisMessageListener.processIncomingMessage(

--- a/cory-serdes-msgpack/src/main/java/moe/rafal/cory/serdes/MessagePackPacketSerdesContext.java
+++ b/cory-serdes-msgpack/src/main/java/moe/rafal/cory/serdes/MessagePackPacketSerdesContext.java
@@ -20,12 +20,13 @@ package moe.rafal.cory.serdes;
 import static org.msgpack.core.MessagePack.newDefaultBufferPacker;
 import static org.msgpack.core.MessagePack.newDefaultUnpacker;
 
-public class MessagePackPacketSerdesContext implements PacketSerdesContext {
-
-  public static final MessagePackPacketSerdesContext INSTANCE =
-      new MessagePackPacketSerdesContext();
+public final class MessagePackPacketSerdesContext implements PacketSerdesContext {
 
   private MessagePackPacketSerdesContext() {}
+
+  public static PacketSerdesContext getMessagePackPacketSerdesContext() {
+    return new MessagePackPacketSerdesContext();
+  }
 
   @Override
   public PacketPacker newPacketPacker() {

--- a/cory-serdes-msgpack/src/main/java/moe/rafal/cory/serdes/MessagePackPacketUnpacker.java
+++ b/cory-serdes-msgpack/src/main/java/moe/rafal/cory/serdes/MessagePackPacketUnpacker.java
@@ -29,6 +29,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import org.msgpack.core.MessageFormat;
 import org.msgpack.core.MessageUnpacker;
 
 class MessagePackPacketUnpacker implements PacketUnpacker {
@@ -172,6 +173,29 @@ class MessagePackPacketUnpacker implements PacketUnpacker {
     }
 
     return null;
+  }
+
+  @Override
+  public Object unpackObject() throws IOException {
+    final MessageFormat nextFormat = underlyingUnpacker.getNextFormat();
+    switch (nextFormat.getValueType()) {
+      case BOOLEAN:
+        return unpackBoolean();
+      case INTEGER:
+        return unpackInt();
+      case FLOAT:
+        return unpackDouble();
+      case STRING:
+        return unpackString();
+      case BINARY:
+        return unpackPayload();
+      case ARRAY:
+        return unpackArray();
+      case MAP:
+        return unpackMap();
+      default:
+        return null;
+    }
   }
 
   @Override

--- a/cory-serdes-msgpack/src/test/java/moe/rafal/cory/MessagePackAssertions.java
+++ b/cory-serdes-msgpack/src/test/java/moe/rafal/cory/MessagePackAssertions.java
@@ -17,12 +17,12 @@
 
 package moe.rafal.cory;
 
+import static moe.rafal.cory.serdes.MessagePackPacketSerdesContext.getMessagePackPacketSerdesContext;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.pivovarit.function.ThrowingBiConsumer;
 import com.pivovarit.function.ThrowingFunction;
 import java.io.IOException;
-import moe.rafal.cory.serdes.MessagePackPacketSerdesContext;
 import moe.rafal.cory.serdes.PacketPacker;
 import moe.rafal.cory.serdes.PacketUnpacker;
 
@@ -36,7 +36,7 @@ public final class MessagePackAssertions {
       T expectedValue)
       throws IOException {
     try (PacketUnpacker unpacker =
-        MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(packer.toBinaryArray())) {
+        getMessagePackPacketSerdesContext().newPacketUnpacker(packer.toBinaryArray())) {
       assertThatUnpackerContains(unpacker, valueResolver, expectedValue);
     }
   }
@@ -65,7 +65,7 @@ public final class MessagePackAssertions {
       T expectedValue)
       throws IOException {
     try (PacketUnpacker unpacker =
-        MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(
+        getMessagePackPacketSerdesContext().newPacketUnpacker(
             getBinaryArrayOf(packerInitializer, expectedValue))) {
       assertThat(valueResolver.apply(unpacker)).isEqualTo(expectedValue);
     }
@@ -74,7 +74,7 @@ public final class MessagePackAssertions {
   public static <T> byte[] getBinaryArrayOf(
       ThrowingBiConsumer<PacketPacker, T, IOException> packetInitializer, T expectedValue)
       throws IOException {
-    PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker();
+    PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker();
     packetInitializer.accept(packer, expectedValue);
     return packer.toBinaryArray();
   }

--- a/cory-serdes-msgpack/src/test/java/moe/rafal/cory/MessagePackPacketTests.java
+++ b/cory-serdes-msgpack/src/test/java/moe/rafal/cory/MessagePackPacketTests.java
@@ -23,10 +23,10 @@ import static moe.rafal.cory.PacketTestsUtils.INCOMING_USERNAME;
 import static moe.rafal.cory.PacketTestsUtils.INITIAL_PASSWORD;
 import static moe.rafal.cory.PacketTestsUtils.INITIAL_USERNAME;
 import static moe.rafal.cory.PacketTestsUtils.getLoginPacket;
+import static moe.rafal.cory.serdes.MessagePackPacketSerdesContext.getMessagePackPacketSerdesContext;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import moe.rafal.cory.serdes.MessagePackPacketSerdesContext;
 import moe.rafal.cory.serdes.PacketPacker;
 import moe.rafal.cory.serdes.PacketUnpacker;
 import moe.rafal.cory.subject.LoginPacket;
@@ -37,10 +37,10 @@ class MessagePackPacketTests {
   @Test
   void writeTest() throws IOException {
     LoginPacket packet = getLoginPacket();
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packet.write(packer);
       try (PacketUnpacker unpacker =
-          MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(packer.toBinaryArray())) {
+          getMessagePackPacketSerdesContext().newPacketUnpacker(packer.toBinaryArray())) {
         MessagePackAssertions.assertThatUnpackerContains(
             unpacker, PacketUnpacker::unpackString, INITIAL_USERNAME);
         MessagePackAssertions.assertThatUnpackerContains(
@@ -60,7 +60,7 @@ class MessagePackPacketTests {
             },
             DEFAULT_VALUE);
     try (PacketUnpacker unpacker =
-        MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(content)) {
+        getMessagePackPacketSerdesContext().newPacketUnpacker(content)) {
       packet.read(unpacker);
       assertThat(packet.getUsername()).isEqualTo(INCOMING_USERNAME);
       assertThat(packet.getPassword()).isEqualTo(INCOMING_PASSWORD);
@@ -70,10 +70,10 @@ class MessagePackPacketTests {
   @Test
   void writeAndReadTest() throws IOException {
     LoginPacket packet = getLoginPacket();
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packet.write(packer);
       try (PacketUnpacker unpacker =
-          MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(packer.toBinaryArray())) {
+          getMessagePackPacketSerdesContext().newPacketUnpacker(packer.toBinaryArray())) {
         LoginPacket clonePacket = new LoginPacket();
         clonePacket.read(unpacker);
         assertThat(clonePacket.getUsername()).isEqualTo(INITIAL_USERNAME);

--- a/cory-serdes-msgpack/src/test/java/moe/rafal/cory/PacketGatewayImplTests.java
+++ b/cory-serdes-msgpack/src/test/java/moe/rafal/cory/PacketGatewayImplTests.java
@@ -19,11 +19,11 @@ package moe.rafal.cory;
 
 import static moe.rafal.cory.PacketTestsUtils.getLoginPacket;
 import static moe.rafal.cory.PacketTestsUtils.getMalformedPacket;
+import static moe.rafal.cory.serdes.MessagePackPacketSerdesContext.getMessagePackPacketSerdesContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.io.IOException;
-import moe.rafal.cory.serdes.MessagePackPacketSerdesContext;
 import moe.rafal.cory.serdes.PacketPacker;
 import moe.rafal.cory.serdes.PacketUnpacker;
 import moe.rafal.cory.subject.LoginPacket;
@@ -37,10 +37,10 @@ class PacketGatewayImplTests {
   @Test
   void writeAndReadPacketTest() throws IOException {
     LoginPacket packet = getLoginPacket();
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packetGateway.writePacket(packet, packer);
       try (PacketUnpacker unpacker =
-          MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(packer.toBinaryArray())) {
+          getMessagePackPacketSerdesContext().newPacketUnpacker(packer.toBinaryArray())) {
         assertThat((LoginPacket) packetGateway.readPacket(unpacker)).isEqualTo(packet);
       }
     }
@@ -49,10 +49,10 @@ class PacketGatewayImplTests {
   @Test
   void writeAndReadPacketShouldThrowWithMissingConstructorTest() throws IOException {
     MalformedPacket packet = getMalformedPacket();
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packetGateway.writePacket(packet, packer);
       try (PacketUnpacker unpacker =
-          MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(packer.toBinaryArray())) {
+          getMessagePackPacketSerdesContext().newPacketUnpacker(packer.toBinaryArray())) {
         assertThatCode(() -> packetGateway.readPacket(unpacker))
             .isInstanceOf(MalformedPacketException.class)
             .hasMessage(
@@ -64,10 +64,10 @@ class PacketGatewayImplTests {
   @Test
   void writeAndReadPacketTypeTest() throws IOException {
     LoginPacket packet = getLoginPacket();
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packetGateway.writePacketType(packet, packer);
       try (PacketUnpacker unpacker =
-          MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(packer.toBinaryArray())) {
+          getMessagePackPacketSerdesContext().newPacketUnpacker(packer.toBinaryArray())) {
         assertThat(packetGateway.readPacketType(unpacker)).isEqualTo(packet.getClass());
       }
     }
@@ -75,10 +75,10 @@ class PacketGatewayImplTests {
 
   @Test
   void writeAndReadPacketTypeShouldThrowWithMissingTypeTest() throws IOException {
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packer.packString("moe.rafal.cory.packet.subject.MissingPacket");
       try (PacketUnpacker unpacker =
-          MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(packer.toBinaryArray())) {
+          getMessagePackPacketSerdesContext().newPacketUnpacker(packer.toBinaryArray())) {
         assertThatCode(() -> packetGateway.readPacketType(unpacker))
             .isInstanceOf(MalformedPacketException.class)
             .hasMessage(
@@ -90,10 +90,10 @@ class PacketGatewayImplTests {
   @Test
   void writeAndReadPacketUniqueIdTest() throws IOException {
     LoginPacket packet = getLoginPacket();
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packetGateway.writePacketUniqueId(packet, packer);
       try (PacketUnpacker unpacker =
-          MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(packer.toBinaryArray())) {
+          getMessagePackPacketSerdesContext().newPacketUnpacker(packer.toBinaryArray())) {
         assertThat(packetGateway.readPacketUniqueId(unpacker)).isEqualTo(packet.getUniqueId());
       }
     }

--- a/cory-serdes-msgpack/src/test/java/moe/rafal/cory/PacketTests.java
+++ b/cory-serdes-msgpack/src/test/java/moe/rafal/cory/PacketTests.java
@@ -28,12 +28,12 @@ import static moe.rafal.cory.PacketTestsUtils.NIL_UNIQUE_ID;
 import static moe.rafal.cory.PacketTestsUtils.getEmptyLoginPacket;
 import static moe.rafal.cory.PacketTestsUtils.getLoginPacket;
 import static moe.rafal.cory.PacketTestsUtils.getMalformedPacket;
+import static moe.rafal.cory.serdes.MessagePackPacketSerdesContext.getMessagePackPacketSerdesContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mockStatic;
 
 import java.io.IOException;
 import java.util.UUID;
-import moe.rafal.cory.serdes.MessagePackPacketSerdesContext;
 import moe.rafal.cory.serdes.PacketPacker;
 import moe.rafal.cory.serdes.PacketUnpacker;
 import moe.rafal.cory.subject.LoginPacket;
@@ -77,10 +77,10 @@ class PacketTests {
   @Test
   void writeTest() throws IOException {
     LoginPacket packet = getLoginPacket();
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packet.write(packer);
       try (PacketUnpacker unpacker =
-          MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(packer.toBinaryArray())) {
+          getMessagePackPacketSerdesContext().newPacketUnpacker(packer.toBinaryArray())) {
         assertThatUnpackerContains(unpacker, PacketUnpacker::unpackString, INITIAL_USERNAME);
         assertThatUnpackerContains(unpacker, PacketUnpacker::unpackString, INITIAL_PASSWORD);
       }
@@ -98,7 +98,7 @@ class PacketTests {
             },
             DEFAULT_VALUE);
     try (PacketUnpacker unpacker =
-        MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(content)) {
+        getMessagePackPacketSerdesContext().newPacketUnpacker(content)) {
       packet.read(unpacker);
       assertThat(packet.getUsername()).isEqualTo(INCOMING_USERNAME);
       assertThat(packet.getPassword()).isEqualTo(INCOMING_PASSWORD);

--- a/cory-serdes-msgpack/src/test/java/moe/rafal/cory/serdes/MessagePackPacketPackerTests.java
+++ b/cory-serdes-msgpack/src/test/java/moe/rafal/cory/serdes/MessagePackPacketPackerTests.java
@@ -23,6 +23,7 @@ import static java.time.Duration.ofDays;
 import static java.time.Duration.ofHours;
 import static java.time.Duration.ofSeconds;
 import static moe.rafal.cory.MessagePackAssertions.packValueAndAssertThatContains;
+import static moe.rafal.cory.serdes.MessagePackPacketSerdesContext.getMessagePackPacketSerdesContext;
 import static moe.rafal.cory.subject.GameState.AWAITING;
 import static moe.rafal.cory.subject.GameState.COUNTING;
 import static moe.rafal.cory.subject.GameState.RUNNING;
@@ -46,7 +47,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 class MessagePackPacketPackerTests {
 
   private final PacketPacker packetPacker =
-      MessagePackPacketSerdesContext.INSTANCE.newPacketPacker();
+      getMessagePackPacketSerdesContext().newPacketPacker();
 
   private static Set<byte[]> getBinarySubjects() {
     return Set.of(
@@ -89,7 +90,7 @@ class MessagePackPacketPackerTests {
 
   @Test
   void closePacketUnpacker() {
-    assertThatCode(() -> MessagePackPacketSerdesContext.INSTANCE.newPacketPacker().close())
+    assertThatCode(() -> getMessagePackPacketSerdesContext().newPacketPacker().close())
         .doesNotThrowAnyException();
   }
 
@@ -164,10 +165,10 @@ class MessagePackPacketPackerTests {
 
   @Test
   void packUUIDWithNullValueTest() throws IOException {
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packer.packUUID(null);
       try (PacketUnpacker unpacker =
-          MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(packer.toBinaryArray())) {
+          getMessagePackPacketSerdesContext().newPacketUnpacker(packer.toBinaryArray())) {
         assertThat(unpacker.unpackUUID()).isNull();
       }
     }
@@ -210,10 +211,10 @@ class MessagePackPacketPackerTests {
 
   @Test
   void packInstantWithNullValueTest() throws IOException {
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packer.packInstant(null);
       try (PacketUnpacker unpacker =
-          MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(packer.toBinaryArray())) {
+          getMessagePackPacketSerdesContext().newPacketUnpacker(packer.toBinaryArray())) {
         assertThat(unpacker.unpackInstant()).isNull();
       }
     }
@@ -228,10 +229,10 @@ class MessagePackPacketPackerTests {
 
   @Test
   void packDurationWithNullValueTest() throws IOException {
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packer.packDuration(null);
       try (PacketUnpacker unpacker =
-          MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(packer.toBinaryArray())) {
+          getMessagePackPacketSerdesContext().newPacketUnpacker(packer.toBinaryArray())) {
         assertThat(unpacker.unpackDuration()).isNull();
       }
     }
@@ -246,10 +247,10 @@ class MessagePackPacketPackerTests {
 
   @Test
   void packEnumWithNullValueTest() throws IOException {
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packer.packDuration(null);
       try (PacketUnpacker unpacker =
-          MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(packer.toBinaryArray())) {
+          getMessagePackPacketSerdesContext().newPacketUnpacker(packer.toBinaryArray())) {
         assertThat((GameState) unpacker.unpackEnum()).isNull();
       }
     }
@@ -257,14 +258,14 @@ class MessagePackPacketPackerTests {
 
   @Test
   void packAutoTest() throws IOException {
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packer.packAuto(10);
       packer.packAuto("test_string");
       packer.packAuto(AWAITING);
       packer.packAuto(Map.of("key", "value", "key2", "value2"));
       packer.packAuto(new String[] {"value", "value1", "value2"});
       try (PacketUnpacker unpacker =
-          MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(packer.toBinaryArray())) {
+          getMessagePackPacketSerdesContext().newPacketUnpacker(packer.toBinaryArray())) {
         assertThat(unpacker.unpackString()).isEqualTo(Integer.class.getName());
         assertThat(unpacker.unpackInt()).isEqualTo(10);
         assertThat(unpacker.unpackString()).isEqualTo(String.class.getName());
@@ -281,10 +282,10 @@ class MessagePackPacketPackerTests {
 
   @Test
   void packAutoWithNullValueTest() throws IOException {
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packer.packAuto(null);
       try (PacketUnpacker unpacker =
-          MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(packer.toBinaryArray())) {
+          getMessagePackPacketSerdesContext().newPacketUnpacker(packer.toBinaryArray())) {
         assertThat(unpacker.hasNextNilValue()).isTrue();
       }
     }

--- a/cory-serdes-msgpack/src/test/java/moe/rafal/cory/serdes/MessagePackPacketUnpackerTests.java
+++ b/cory-serdes-msgpack/src/test/java/moe/rafal/cory/serdes/MessagePackPacketUnpackerTests.java
@@ -23,6 +23,7 @@ import static java.time.Duration.ofHours;
 import static java.time.Duration.ofSeconds;
 import static moe.rafal.cory.MessagePackAssertions.getBinaryArrayOf;
 import static moe.rafal.cory.MessagePackAssertions.unpackValueAndAssertThatEqualTo;
+import static moe.rafal.cory.serdes.MessagePackPacketSerdesContext.getMessagePackPacketSerdesContext;
 import static moe.rafal.cory.subject.GameState.AWAITING;
 import static moe.rafal.cory.subject.GameState.COUNTING;
 import static moe.rafal.cory.subject.GameState.RUNNING;
@@ -74,7 +75,7 @@ class MessagePackPacketUnpackerTests {
   @AfterEach
   void closePacketUnpacker() {
     assertThatCode(
-            () -> MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(new byte[0]).close())
+            () -> getMessagePackPacketSerdesContext().newPacketUnpacker(new byte[0]).close())
         .doesNotThrowAnyException();
   }
 
@@ -89,7 +90,7 @@ class MessagePackPacketUnpackerTests {
             },
             DEFAULT_VALUE);
     try (PacketUnpacker unpacker =
-        MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(content)) {
+        getMessagePackPacketSerdesContext().newPacketUnpacker(content)) {
       assertThat(unpacker.unpackString()).isEqualTo("test_string_1");
       unpacker.skipValue();
       assertThat(unpacker.unpackString()).isEqualTo("test_string_3");
@@ -199,10 +200,10 @@ class MessagePackPacketUnpackerTests {
 
   @Test
   void unpackInstantWithNullValueTest() throws IOException {
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packer.packDuration(null);
       try (PacketUnpacker unpacker =
-          MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(packer.toBinaryArray())) {
+          getMessagePackPacketSerdesContext().newPacketUnpacker(packer.toBinaryArray())) {
         assertThat(unpacker.unpackInstant()).isNull();
       }
     }
@@ -217,10 +218,10 @@ class MessagePackPacketUnpackerTests {
 
   @Test
   void unpackDurationWithNullValueTest() throws IOException {
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packer.packDuration(null);
       try (PacketUnpacker unpacker =
-          MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(packer.toBinaryArray())) {
+          getMessagePackPacketSerdesContext().newPacketUnpacker(packer.toBinaryArray())) {
         assertThat(unpacker.unpackDuration()).isNull();
       }
     }
@@ -234,10 +235,10 @@ class MessagePackPacketUnpackerTests {
 
   @Test
   void unpackEnumWithNullValueTest() throws IOException {
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packer.packEnum(null);
       try (PacketUnpacker unpacker =
-          MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(packer.toBinaryArray())) {
+          getMessagePackPacketSerdesContext().newPacketUnpacker(packer.toBinaryArray())) {
         assertThat((GameState) unpacker.unpackEnum()).isNull();
       }
     }
@@ -246,7 +247,7 @@ class MessagePackPacketUnpackerTests {
   @Test
   void hasNextOnEmptyUnpackerTest() throws IOException {
     try (PacketUnpacker unpacker =
-        MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(new byte[0])) {
+        getMessagePackPacketSerdesContext().newPacketUnpacker(new byte[0])) {
       assertThat(unpacker.hasNext()).isFalse();
     }
   }
@@ -254,7 +255,7 @@ class MessagePackPacketUnpackerTests {
   @Test
   void hasNextOnExhaustedUnpackerTest() throws IOException {
     try (PacketUnpacker unpacker =
-        MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(
+        getMessagePackPacketSerdesContext().newPacketUnpacker(
             getBinaryArrayOf(PacketPacker::packInt, 1))) {
       assertThat(unpacker.hasNext()).isTrue();
     }
@@ -262,10 +263,10 @@ class MessagePackPacketUnpackerTests {
 
   @Test
   void hasNextNilValueOnNilElement() throws IOException {
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packer.packNil();
       try (PacketUnpacker unpacker =
-          MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(packer.toBinaryArray())) {
+          getMessagePackPacketSerdesContext().newPacketUnpacker(packer.toBinaryArray())) {
         assertThat(unpacker.hasNextNilValue()).isTrue();
       }
     }
@@ -273,10 +274,10 @@ class MessagePackPacketUnpackerTests {
 
   @Test
   void hasNextNilValueOnAnyElement() throws IOException {
-    try (PacketPacker packer = MessagePackPacketSerdesContext.INSTANCE.newPacketPacker()) {
+    try (PacketPacker packer = getMessagePackPacketSerdesContext().newPacketPacker()) {
       packer.packDuration(ZERO);
       try (PacketUnpacker unpacker =
-          MessagePackPacketSerdesContext.INSTANCE.newPacketUnpacker(packer.toBinaryArray())) {
+          getMessagePackPacketSerdesContext().newPacketUnpacker(packer.toBinaryArray())) {
         assertThat(unpacker.hasNextNilValue()).isFalse();
       }
     }


### PR DESCRIPTION
Add packet preview to logs to enhance debugging; Use static accessor to resolve message pack's packet serdes context instead of singleton

Closing #141 